### PR TITLE
Fix infinite loop and out of memory error

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -671,6 +671,11 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 );
 
         $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+
+        if ($start === false) {
+            return '';
+        }
+
         // Bow out if the next token is a variable as we don't know where it was defined.
         if ($tokens[$start]['code'] === T_VARIABLE) {
             return '';


### PR DESCRIPTION
Fix infinite loop and out of memory error when class is not found.
While trying to check a legacy application for PHP compatibility issues, code sniffer terminated with out of memory error. This error is caused by infinite loop in Sniff.php.
Test code:
`<?php
$var = new
`

Creating a pull request with a fix.